### PR TITLE
specify urllib import in update_commdat.py

### DIFF
--- a/update_commdat.py
+++ b/update_commdat.py
@@ -12,7 +12,7 @@ import numpy as np
 import time as tt
 import pandas as pd
 import datetime as dt
-import urllib
+import urllib.request
 import re
 
 class update_etpred_data(object):


### PR DESCRIPTION
Only `import urllib` may not work in later versions of Python 3: https://stackoverflow.com/a/41217363/4174466

first run attempt produced:
```python
$ python update_commdat.py
--------------------------------------
-->> Updating time conversion database 'commdat/[raw]_Leap_Second_History.dat':
Traceback (most recent call last):
  File "update_commdat.py", line 339, in <module>
    pt.update_etddt()
  File "update_commdat.py", line 270, in update_etddt
    urllib.request.urlopen(self.leapsec_rfile)
AttributeError: module 'urllib' has no attribute 'request'
```